### PR TITLE
Fixed case-sensitivity issue with calling the updatePassword view

### DIFF
--- a/hq/handlers/general.cfc
+++ b/hq/handlers/general.cfc
@@ -357,7 +357,7 @@
 	</cffunction>
 
 	<cffunction name="updatePassword" access="public" returntype="void">
-		<cfset setView("UpdatePassword")>
+		<cfset setView("updatePassword")>
 	</cffunction>
 	
 	<cffunction name="doStart" access="public" returnType="void">


### PR DESCRIPTION
When I installed BugLogHQ in a case-sensitive Unix environment, I could not get past the mandatory admin password change step because the updatePassword.cfm file wouldn't be invoked (the HTML form to change the password would not appear).  The error stated it could not find the "UpdatePassword.cfm" template.

I tracked the issue down to this line:  changing it fixed the problem.
