### PR TITLE
Adjustments to Ant build.xml from issue #37

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -24,6 +24,6 @@
 
 
 	<target name="archive" depends="clean">
-		<zip destfile="${output}${archive}" basedir="${src}" excludes="deploy/,install/,test/,*.git/**,.settings/**,.project,build.xml,README.md,.pydevproject" defaultexcludes="yes"/>
+		<zip destfile="${output}${archive}" basedir="${src}" excludes="deploy/,install/,*.git/**,.settings/**,.project,build.xml,README.md,.pydevproject" defaultexcludes="yes"/>
 	</target>
 </project>


### PR DESCRIPTION
"lib" folder is currently not required.
"test" folder is now included in the deployment ZIP.
