### PR TITLE
Display remote address in Exception Summary

### DIFF
--- a/client/bugLogService.cfc
+++ b/client/bugLogService.cfc
@@ -348,6 +348,10 @@
 					<td>#HtmlEditFormat(cgi.HTTP_USER_AGENT)#</td>
 				</tr>
 				<tr>
+					<td><b>Remote Address:</b></td>
+					<td>#HtmlEditFormat(cgi.REMOTE_ADDR)#</td>
+				</tr>
+				<tr>
 					<td><b>Referrer:</b></td>
 					<td>#HtmlEditFormat(cgi.HTTP_REFERER)#</td>
 				</tr>


### PR DESCRIPTION
We found it really useful to know the remote address when a bug comes in. Maybe others will find it useful, too.
