### PR TITLE
Properly scoping variables as URL

### DIFF
--- a/util/processQueue.cfm
+++ b/util/processQueue.cfm
@@ -1,13 +1,13 @@
 <cfsetting requesttimeout="120">	<!--- set request timeout to 120 seconds to minimize overlapping with the next scheduler run --->
 
-<cfparam name="key" type="string" default="">
-<cfparam name="instance" type="string" default="">
+<cfparam name="url.key" type="string" default="">
+<cfparam name="url.instance" type="string" default="">
 
 <!--- Handle service initialization if necessary --->
-<cfset oService = createObject("component", "bugLog.components.service").init( instanceName = instance )>
+<cfset oService = createObject("component", "bugLog.components.service").init( instanceName = url.instance )>
 
 <!--- process queue --->
 <cfif oService.isRunning()>
 	<cfset oBugLogListener = oService.getService()>
-	<cfset oBugLogListener.processQueue( key )>
+	<cfset oBugLogListener.processQueue( url.key )>
 </cfif>


### PR DESCRIPTION
This fixes an issue where restricted scope cascading (as is available in Railo) will cause the scheduled task to never process the queue.
