### PR TITLE
[Enh] Add HTML5 autofocus to login's username field.

### DIFF
--- a/hq/views/login.cfm
+++ b/hq/views/login.cfm
@@ -24,7 +24,7 @@
 	#resetApp {
 		font-size:10px;
 		margin-top:15px;
-		color:#333;	
+		color:#333;
 	}
 </style>
 <br>
@@ -32,7 +32,7 @@
 <cfoutput>
 	<form name="frmLogin" action="index.cfm?#qs#" method="post">
 		<input type="hidden" name="event" value="doLogin">
-		
+
 		<table align="center" border="0" cellpadding="2" cellspacing="0" class="tblLogin">
 			<tr>
 				<td rowspan="5" style="border-right:1px solid ##ccc;width:150px;" valign="middle" align="center">
@@ -41,7 +41,7 @@
 						Version: <strong>#versionTag#</strong>
 					</div>
 					<div id="resetApp">
-						<a href="index.cfm?resetApp=1" style="color:##333;" 
+						<a href="index.cfm?resetApp=1" style="color:##333;"
 							alt="Resetting the application will force a reload of any configuration settings"
 							title="Resetting the application will force a reload of any configuration settings">Reset BugLogHQ</a>
 					</div>
@@ -51,8 +51,8 @@
 			<tr>
 				<td width="100" valign="middle" style="font-size:11px;" align="right"><b>Username:</b></td>
 				<td valign="middle" colspan="2">
-					<input style="font-size:11px;width:100px" 
-							type="text" name="username" 
+					<input style="font-size:11px;width:100px"
+							type="text" name="username" autofocus="autofocus"
 							required="yes" message="Your username is required">
 				</td>
 			</tr>
@@ -60,7 +60,7 @@
 				<td valign="middle" style="font-size:11px;" align="right"><b>Password:</b></td>
 				<td valign="middle">
 					<input style="font-size:11px;width:100px"
-							type="password" name="password" 
+							type="password" name="password"
 							required="yes" message="Your password is required">
 				</td>
 			</tr>


### PR DESCRIPTION
Gives the username field HTML5 autofocus on load and fixes a minor copy&paste error in the username field's validation message (the username field complained about some email address).
