### PR TITLE
Add missing semicolon.

### DIFF
--- a/hq/handlers/general.cfc
+++ b/hq/handlers/general.cfc
@@ -636,7 +636,7 @@
 				if(criteria.numdays lt 1)
 					criteria.startDate = dateAdd("h", criteria.numDays * 24 * -1, now());
 				else
-					criteria.startDate = dateAdd("d", val(criteria.numDays) * -1, now())
+					criteria.startDate = dateAdd("d", val(criteria.numDays) * -1, now());
 			}
 
 			// build a url to tihs page with the full criteria


### PR DESCRIPTION
Someone forgot to add a semicolon to the end of a CFScript line. 
This minor fix will allow the code to run on ACF again.
