### PR TITLE
Use correct sql types for primary keys

### DIFF
--- a/components/db/applicationDAO.cfc
+++ b/components/db/applicationDAO.cfc
@@ -2,7 +2,7 @@
 	
 	<cffunction name="initTableParams" access="package" returntype="void" hint="setup table specific settings">
 		<cfset setTableName("bl_Application")>
-		<cfset setPrimaryKey("applicationID","cf_sql_varchar")>
+		<cfset setPrimaryKey("applicationID","cf_sql_numeric")>
 		<cfset setLabelField("code","cf_sql_varchar")>
 		
 		<cfset addColumn("code", "cf_sql_varchar")>

--- a/components/db/entryDAO.cfc
+++ b/components/db/entryDAO.cfc
@@ -2,8 +2,8 @@
 	
 	<cffunction name="initTableParams" access="package" returntype="void" hint="setup table specific settings">
 		<cfset setTableName("bl_Entry")>
-		<cfset setPrimaryKey("entryID","cf_sql_varchar")>
-		<cfset setLabelField("entryID","cf_sql_varchar")>
+		<cfset setPrimaryKey("entryID","cf_sql_numeric")>
+		<cfset setLabelField("entryID","cf_sql_numeric")>
 		
 		<cfset addColumn("mydateTime", "cf_sql_timestamp")>
 		<cfset addColumn("message", "cf_sql_varchar")>

--- a/components/db/hostDAO.cfc
+++ b/components/db/hostDAO.cfc
@@ -2,7 +2,7 @@
 	
 	<cffunction name="initTableParams" access="package" returntype="void" hint="setup table specific settings">
 		<cfset setTableName("bl_Host")>
-		<cfset setPrimaryKey("hostID","cf_sql_varchar")>
+		<cfset setPrimaryKey("hostID","cf_sql_numeric")>
 		<cfset setLabelField("hostName","cf_sql_varchar")>
 
 		<cfset addColumn("hostName", "cf_sql_varchar")>

--- a/components/db/severityDAO.cfc
+++ b/components/db/severityDAO.cfc
@@ -2,7 +2,7 @@
 	
 	<cffunction name="initTableParams" access="package" returntype="void" hint="setup table specific settings">
 		<cfset setTableName("bl_Severity")>
-		<cfset setPrimaryKey("severityID","cf_sql_varchar")>
+		<cfset setPrimaryKey("severityID","cf_sql_numeric")>
 		<cfset setLabelField("code","cf_sql_varchar")>
 		
 		<cfset addColumn("code", "cf_sql_varchar")>

--- a/components/db/sourceDAO.cfc
+++ b/components/db/sourceDAO.cfc
@@ -2,7 +2,7 @@
 	
 	<cffunction name="initTableParams" access="package" returntype="void" hint="setup table specific settings">
 		<cfset setTableName("bl_Source")>
-		<cfset setPrimaryKey("sourceID","cf_sql_varchar")>
+		<cfset setPrimaryKey("sourceID","cf_sql_numeric")>
 		<cfset setLabelField("name","cf_sql_varchar")>
 		
 		<cfset addColumn("name", "cf_sql_varchar")>

--- a/components/db/userApplicationDAO.cfc
+++ b/components/db/userApplicationDAO.cfc
@@ -2,7 +2,7 @@
 	
 	<cffunction name="initTableParams" access="package" returntype="void" hint="setup table specific settings">
 		<cfset setTableName("bl_UserApplication")>
-		<cfset setPrimaryKey("UserApplicationID","cf_sql_varchar")>
+		<cfset setPrimaryKey("UserApplicationID","cf_sql_numeric")>
 		
 		<cfset addColumn("UserID", "cf_sql_numeric")>
 		<cfset addColumn("ApplicationID", "cf_sql_numeric")>

--- a/components/db/userDAO.cfc
+++ b/components/db/userDAO.cfc
@@ -2,7 +2,7 @@
 	
 	<cffunction name="initTableParams" access="package" returntype="void" hint="setup table specific settings">
 		<cfset setTableName("bl_User")>
-		<cfset setPrimaryKey("UserID","cf_sql_varchar")>
+		<cfset setPrimaryKey("UserID","cf_sql_numeric")>
 		<cfset setLabelField("Username","cf_sql_varchar")>
 		
 		<cfset addColumn("Username", "cf_sql_varchar")>


### PR DESCRIPTION
PostgreSQL is strict about the sql type matching that of the columns
