### PR TITLE
notifyService() needs some minor null handling when REST is used.

### DIFF
--- a/client/bugLogService.cfc
+++ b/client/bugLogService.cfc
@@ -184,7 +184,11 @@
 							<cfhttpparam type="body" value="#serializeJson(data)#">
 						<cfelse>
 							<cfloop list="#structKeyList(data)#" index="key">
-								<cfhttpparam type="formfield" name="#key#" value="#data[key]#">
+								<cfif isNull(data[key])>
+									<cfhttpparam type="formfield" name="#key#" value="null">
+								<cfelse>
+									<cfhttpparam type="formfield" name="#key#" value="#data[key]#">
+								</cfif>
 							</cfloop>
 						</cfif>
 					</cfhttp>


### PR DESCRIPTION
This concerns something a colleague of mine ran into earlier.
Without a precaution in this spot the service could run into a NullPointerException if a variable contains a null.
