### PR TITLE
[Fix] Provide exception details if the ExtraInfo dump crashes

### DIFF
--- a/client/bugLogService.cfc
+++ b/client/bugLogService.cfc
@@ -421,7 +421,15 @@
 
 			<cfif not isSimpleValue(arguments.ExtraInfo) or arguments.ExtraInfo neq "">
 				<h3>Additional Info</h3>
-				#sanitizeDump(arguments.ExtraInfo, arguments.maxDumpDepth)#
+				<cftry>
+					#sanitizeDump(arguments.ExtraInfo, arguments.maxDumpDepth)#
+					<cfcatch>
+						<div style="margin-left:80px;">
+							<h4 style="color:red;">Failed to convert <strong>ExtraInfo</strong> into a HTML representation!</h4>
+							#sanitizeDump(CFCATCH, arguments.maxDumpDepth)#
+						</div>
+					</cfcatch>
+				</cftry>
 			</cfif>
 
 			<cfset var checkpoints = getCheckpoints()>


### PR DESCRIPTION
Here's a fix for another problem a colleague of mine ran into again today:

If dumping the ExtraInfo fails, this will at least provide some information on why that aspect failed and deliver the rest of the data for the original exception.

A common example for this problem is if the ExtraInfo variable contains a reference to a Hibernate object that has lazily initialized properties.
In case the Hibernate session for that object has already been closed (or just plain crashed), the dump process would throw a LazyInitializationException and drag the rest of the bug report with it.

At least in this case we'll still have the message/detail information, both traces and some other data to solve the initial problem.
Since I can't simply make assumptions on which parameters were sent to the notifyService() method I can't report this inner exception as a separate bug through the regular channels and have to provide its details inline.
