### PR TITLE
Take care of the symptom of the "Invalid data '' for CFSQLTYPE CF_SQL_NU...

### DIFF
--- a/components/lib/dao/dbDataProvider.cfc
+++ b/components/lib/dao/dbDataProvider.cfc
@@ -61,7 +61,7 @@
 					<cfif listLen(arguments.id) gt 1>
 						#PKName# IN (<cfqueryparam cfsqltype="#PKType#" value="#arguments.id#" list="true">)
 					<cfelse>
-						#PKName# = <cfqueryparam cfsqltype="#PKType#" value="#arguments.id#" null="#len(trim(arguments.id))#">
+						#PKName# = <cfqueryparam cfsqltype="#PKType#" value="#arguments.id#" null="#!len(trim(arguments.id))#">
 					</cfif>
 		</cfquery>
 	</cffunction>


### PR DESCRIPTION
...MERIC." errors.

This is an extension of issue #73 and only fixes the symptom (failed database query), but not the reason why the ID (probably the applicationID was an empty string in the first place.
