### PR TITLE
Fixes issue #86

### DIFF
--- a/client/bugLogService.cfc
+++ b/client/bugLogService.cfc
@@ -495,6 +495,7 @@
 		<cfelse>
 			<cfsavecontent variable="out"><cfoutput><cfdump var="#arguments.data#" top="#arguments.maxDumpDepth#"></cfoutput></cfsavecontent>
 			<cfset out = reReplaceNoCase(out, "<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>", "<em>JavaScript code removed for security</em>","all")>
+			<cfset out = replace(out, ">", ">#Chr(10) & Chr(13)#","all")>
 		</cfif>
 		<cfreturn out>
 	</cffunction>


### PR DESCRIPTION
By adding Chr(10) and Chr(13) after every greater than symbol we ensure
that no one line gets too long.
