### PR TITLE
Fixes issue #91

### DIFF
--- a/components/xmlConfigProvider.cfc
+++ b/components/xmlConfigProvider.cfc
@@ -62,7 +62,7 @@
 			if(variables.configKey neq "") {
 				for(i=1;i lte arrayLen(xmlDoc.xmlRoot.xmlChildren);i=i+1) {
 					xmlNode = xmlDoc.xmlRoot.xmlChildren[i];
-					if(xmlNode.xmlName eq "envSettings") {
+					if(xmlNode.xmlName eq "envSettings" && xmlNode.xmlAttributes.name eq variables.configKey) {
 						for(j=1;j lte arrayLen(xmlNode.xmlChildren);j=j+1) {
 							xmlChildNode = xmlNode.xmlChildren[j];
 							cfg[xmlChildNode.xmlAttributes.name] = structNew();


### PR DESCRIPTION
Checks envSettings.name against configKey. This logic had been in the
XPath syntax from before and just didn't translate when refactoring. As
a result, BugLog would always use your last listed envSettings.
