### PR TITLE
Fixes an issue where slashes were doubling up.

### DIFF
--- a/components/jiraService.cfc
+++ b/components/jiraService.cfc
@@ -20,8 +20,6 @@
 				if(cgi.server_port neq 80) thisHost = thisHost & ":" & cgi.server_port;
 				variables.instance.endpoint = thisHost & variables.instance.endpoint;
 			}
-			if(right(variables.instance.endpoint,1) neq "/")
-				variables.instance.endpoint = variables.instance.endpoint & "/";
 		</cfscript>
 		<cfreturn this>
 	</cffunction>


### PR DESCRIPTION
jiraService init was adding a trailing slash if none was defined, but the functions were already compensating for this, causing double slashes and 404 errors in the requests.
