### PR TITLE
Escape cgi.QUERY_STRING

### DIFF
--- a/client/bugLogService.cfc
+++ b/client/bugLogService.cfc
@@ -305,7 +305,7 @@
 			// reconstruct full URL
 			tmpURL = getPageContext().getRequest().getRequestURL();
 			if(cgi.QUERY_STRING neq "")
-				tmpURL = tmpURL & "?" & cgi.QUERY_STRING;
+				tmpURL = xmlFormat(tmpURL & "?" & cgi.QUERY_STRING);
 		</cfscript>
 
 


### PR DESCRIPTION
Given an example Query_String of:
`<meta HTTP-EQUIV="refresh" CONTENT="0; URL=http://google.com">`
The META tag will be rendered as HTML in the entry Detail view,
therefore cause an instant page-reload and send whoever is viewing the BugLog entry to visit a site chosen by the 'attacker'.