### PR TITLE
Fix typo in config XML

### DIFF
--- a/config/buglog-config.xml.cfm
+++ b/config/buglog-config.xml.cfm
@@ -74,7 +74,7 @@
 		<setting name="mail.port"></setting>
 		<setting name="mail.username"></setting>
 		<setting name="mail.password"></setting>
-		<setting name="mail.useTSL"></setting>
+		<setting name="mail.useTLS"></setting>
 		<setting name="mail.useSSL"></setting>
 	-->
 


### PR DESCRIPTION
Editing config without noticing this typo results in errors when attempting to send email via BugLogHQ. Errors within error reporting causes infinite error generation! ;)